### PR TITLE
Add `Value` to PureDropdown

### DIFF
--- a/src/PureBlazor.Components/Buttons/PureDropdown.razor.cs
+++ b/src/PureBlazor.Components/Buttons/PureDropdown.razor.cs
@@ -54,5 +54,9 @@ public class DropdownMenuItem
     /// The text to display on the menu item.
     /// </summary>
     public string? Text { get; set; }
+    /// <summary>
+    /// The value to send to the server.
+    /// </summary>
+    public string? Value { get; set; }
 }
 


### PR DESCRIPTION
# Add `Value` to PureDropdown

Adds a `Value` field to the Dropdown

## Description

This allows the 'id' used for logic, and the text used for the browser to be separate.