### PR TITLE
Missing `,` in #20

### DIFF
--- a/src/PureBlazor.Components/Icons/PureIcon.razor.cs
+++ b/src/PureBlazor.Components/Icons/PureIcon.razor.cs
@@ -97,7 +97,7 @@ public enum PureIcons
     IconBeaker,
     IconSignOut,
     IconEllipsis,
-    IconLanguage
+    IconLanguage,
     IconSquareStack,
     IconCloud
 }


### PR DESCRIPTION
# Missing `,` from #20 

Merge commit dropped the added comma for IconLanguage
