### PR TITLE
PureInput Value Patch

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,7 +122,7 @@
     <PackageVersion Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Testcontainers" Version="3.8.0" />
     <PackageVersion Include="Ulid" Version="1.3.3" />
     <PackageVersion Include="Wasmtime" Version="19.0.1" />

--- a/src/Pure.Blazor.Components/Forms/PureInput.razor.cs
+++ b/src/Pure.Blazor.Components/Forms/PureInput.razor.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
 using Pure.Blazor.Components.Forms.Validators;
 using Pure.Blazor.Components.Primitives;
 
@@ -15,12 +16,21 @@ public partial class PureInput
     private string defaultBorder = "border-gray-200";
     private string errorBorder = "border-red-600";
     private string? errorMessage;
-    private object? innerValue;
 
     private string? TextValue
     {
-        get { return innerValue?.ToString(); }
-        set { innerValue = value; }
+        get
+        {
+            return Value?.ToString();
+        }
+        set
+        {
+            // We abuse the fact that we bind Text-Value instead of Value directly.
+            // updates are sent via OnValue up to the actual user inputted bind
+            // Since we never update 'TextValue', only the getter is required to be implemented
+            // The compiler still requires a setter
+            Log.LogDebug("TextValue's `set` is not implemented; please use Value's `set`");
+        }
     }
 
     // the suffix needs different margins depending on labels and helper text
@@ -141,7 +151,6 @@ public partial class PureInput
 
     protected override void OnInitialized()
     {
-        innerValue = Value ?? default;
 
         if (Required == true)
         {


### PR DESCRIPTION
# PureInput Value Patch

## Description
Bumps System.Text.Json to 8.0.5, unrelated to bug

When PureInput's binding value changes, the content does not update.

This was caused by the wrapper value innerValue only being assigned on creation.

To minimize changes, I abused the fact that TextValue's only purpose is to serve as a bind target 'getter' to minimize code changes.

TextValue now directly exposes the underlying Value parameter, while OnChange/OnInput update Value parameter via ValueChanged